### PR TITLE
refactor(podcast index): change layout of podcasts

### DIFF
--- a/app/routes/modern-web-podcast/index.js
+++ b/app/routes/modern-web-podcast/index.js
@@ -1,15 +1,64 @@
 import Ember from 'ember';
 
-const ensureImage = (project) => (podcast) => project({
-  ...podcast,
-  imageURL: podcast.imageURL || `http://img.youtube.com/vi/${podcast.id}/hqdefault.jpg`
-});
 
-const splitDescriptionParagraphs = (project) => (podcast) => project({
-  ...podcast,
+/*
+NOTES FOR TRACY
+=========================
+
+1. What is Object.assign? It's a way to copy an properties from a list of objects onto another object.
+   So if you do `Object.assign(a, b, c)` it's going to take all of the properties from b and c and copy them
+   onto `a`, then return `a`. If you want to duplicate an object, so you don't alter the original object, you'd
+   do: `const copy = Object.assign({}, original);`
+2. This uses "functional programming" an higher-order functions in a fairly basic way. However, these techniques
+   can be confusing even for advanced developers. So if it looks weird to you, take heart, it looks weird to 90%
+   of developers too, for the most part.
+*/
+
+/**
+  higher-order function to ensure there's an image on each podcast in a list. It's a "higher-order"
+  function because it's a function that returns a function.
+
+  This looks funny, because it's a function written so you can chain it with other functions.
+  That way we can loop through the podcasts _only once_ with a map (below), and fix them
+  all in one go.
+
+  @param {function} project - This is a projection function, a projection function is any function that
+    can be used with an Array `map`. It projects a value from the array into a new value.
+
+  @returns {function} a projection function! When you call `ensureImage` it's going to take a function
+    you can use in an Array `map`, and return a function you can use in an Array `map`. It chains two
+    transformations together, so you you only have to `map` once.
+*/
+const ensureImage = (project) => (podcast) => project(Object.assign({}, podcast, {
+  imageURL: podcast.imageURL || `http://img.youtube.com/vi/${podcast.id}/hqdefault.jpg`
+}));
+
+/**
+  An ordinary projection function that copies a podcast object onto a new one, but adds the list of
+  descriptionParagraphs
+  @param {object} podcast the podcast you want to add the descriptionParagraphs to
+  @returns {object} a new podcast object with the descriptionParagraphs property added.
+*/
+const splitDescriptionParagraphs = (podcast) => Object.assign({}, podcast, {
   descriptionParagraphs: podcast.description.split('\n')
 });
 
+/**
+  Takes an array and groups it into a new array of arrays of 3 (or less) items.
+  So: `[a, b, c, d, e, f, g, h]` becomes `[[a, b, c], [d, e, f], [g, h]]`
+
+  NOTE: The cool thing too look up and learn about here is `Array.prototype.reduce`.
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce
+
+  It's a way to iterate over the items in an array and track some sort of state while you're doing so,
+  ultimately returning the state. In the example below, I'm iterating through all items in `arr`,
+  and I'm tracking two pieces of state: 1. The current `group` of three I'm building,
+  and 2. The `groups` list I'm adding groups too. At the end, the `reduce` call returns the entire state,
+  and I get just the `.groups` property off of it and return.
+
+  @param {Array} arr the array to create the results from
+  @returns {Array} an array of arrays grouped into threes
+*/
 const groupsOfThree = (arr) =>
   (arr.reduce(({ group, groups }, item, i) => {
     if (!group || i % 3 === 0) {
@@ -23,8 +72,8 @@ const groupsOfThree = (arr) =>
 export default Ember.Route.extend({
   model() {
     const model = this.modelFor('modern-web-podcast');
-    const podcasts = model.podcasts.map(ensureImage(splitDescriptionParagraphs(x => x)))
+    const podcasts = model.podcasts.map(ensureImage(splitDescriptionParagraphs));
     const groupedPodcasts = groupsOfThree(podcasts);
-    return { ...model, podcasts, groupedPodcasts };
+    return Object.assign({}, model, { podcasts, groupedPodcasts });
   }
 });

--- a/app/routes/modern-web-podcast/index.js
+++ b/app/routes/modern-web-podcast/index.js
@@ -1,7 +1,30 @@
 import Ember from 'ember';
 
+const ensureImage = (project) => (podcast) => project({
+  ...podcast,
+  imageURL: podcast.imageURL || `http://img.youtube.com/vi/${podcast.id}/hqdefault.jpg`
+});
+
+const splitDescriptionParagraphs = (project) => (podcast) => project({
+  ...podcast,
+  descriptionParagraphs: podcast.description.split('\n')
+});
+
+const groupsOfThree = (arr) =>
+  (arr.reduce(({ group, groups }, item, i) => {
+    if (!group || i % 3 === 0) {
+      group = [];
+      groups.push(group);
+    }
+    group.push(item);
+    return { groups, group };
+  }, { group: null, groups: [] })).groups;
+
 export default Ember.Route.extend({
   model() {
-    return this.modelFor('modern-web-podcast');
+    const model = this.modelFor('modern-web-podcast');
+    const podcasts = model.podcasts.map(ensureImage(splitDescriptionParagraphs(x => x)))
+    const groupedPodcasts = groupsOfThree(podcasts);
+    return { ...model, podcasts, groupedPodcasts };
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -33,6 +33,14 @@ $sponsor_logo: 400px;
 
 // end font sizes
 
+.force-wrap {
+  white-space: normal !important;
+}
+
+.white-text-background {
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
 // sticky footer
 body, html {
 	background-color: #fafafa;
@@ -214,17 +222,7 @@ $medium-only: "only screen and (min-width : #{$small-screen-up}) and (max-width 
   break-inside: $ct;
 }
 
-.cards-container {
-  .card {
-    display: inline-block;
-    overflow: visible;
-  }
-  .card-panel-wrapper {
-    margin-bottom: 5px;
-    padding-bottom: 10px;
-    padding-top: 10px;
-    margin-top: 5px;
-  }
+.new-cards-container {
   .card-panel {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -241,6 +239,13 @@ $medium-only: "only screen and (min-width : #{$small-screen-up}) and (max-width 
       background-position: center;
     }
   }
+}
+
+.responsive-img{
+  height:240px;
+  background-repeat:no-repeat;
+  background-size:cover;
+  background-position: center;
 }
 
 @media #{$small-and-down} {

--- a/app/templates/modern-web-podcast/index.hbs
+++ b/app/templates/modern-web-podcast/index.hbs
@@ -14,13 +14,38 @@
 </div>
 {{!-- end snap button --}}
 
-{{!-- <div class="row"> --}}
-<div class="col s12 cards-container">
-		{{#each model.podcasts as |podcast| }}
-			{{iframe-card model=podcast}}
-		{{/each}}
-	{{!-- </div> --}}
+
+<div class="new-cards-container">
+	{{#each model.groupedPodcasts as |podcastGroup| }}
+		<div class="row">
+			{{#each podcastGroup as |podcast|}}
+				<div class="col l4 m6 s12">
+						<div class="card black-text" style="min-height: 349px">
+	            <div class="card-image">
+								{{#link-to 'modern-web-podcast.podcast' podcast.vanity}}
+									{{#if (eq podcast.type 'podbean')}}
+										<img src="{{podcast.imageURL}}"/>
+									{{else}}
+										<div class='video static-podcast responsive-img' style='background-image:url("{{podcast.imageURL}}")' alt={{podcast.title}}></div>
+									{{/if}}
+
+		              <span class="card-title force-wrap {{if (eq podcast.type 'podbean') 'black-text white-text-background'}}">{{podcast.title}}</span>
+								{{/link-to}}
+	            </div>
+	            <div class="card-content">
+								{{#read-more maxHeight="3.1em"}}
+									{{#each podcast.descriptionParagraphs as |description|}}
+						        <p>{{description}}</p>
+						      {{/each}}
+								{{/read-more}}
+	            </div>
+	          </div>
+				</div>
+			{{/each}}
+		</div>
+	{{/each}}
 </div>
+
 
 {{!-- add giga --}}
 <div class="row">

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "ember-modal-dialog": "0.8.2",
     "ember-new-computed": "1.0.3",
     "ember-radio-button": "1.0.7",
+    "ember-read-more": "0.0.13",
     "ember-truth-helpers": "1.2.0",
     "emberfire": "1.6.3",
-    "rainbow-tail": "0.0.2"
+    "rainbow-tail": "0.0.2",
+    "read-more": "0.0.0"
   }
 }


### PR DESCRIPTION
- descriptions will now collapse
- titles are now laid over top of the image
- NOTE: index page no longer uses the md-card-panel component as it was inefficient.
- NOTE: ifrome-panel is no longer used in the index, the podcast detail screen might be best off refactored at some point just to have its own template and logic

<3
